### PR TITLE
Add basic accounting dashboard with CSV upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# accounting
-accounting software for axon financial group
+# Accounting Dashboard
+
+Simple web dashboard for uploading transaction CSVs and generating Profit & Loss, Balance Sheet, and GST summaries for a small mortgage broking business.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the app
+
+```bash
+python app.py
+```
+
+Open <http://localhost:5000> in your browser and upload a CSV with columns: `date, description, amount, category, gst`.
+
+## Tests
+
+```bash
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,54 @@
+from flask import Flask, render_template, request, redirect
+import pandas as pd
+
+app = Flask(__name__)
+
+
+def parse_transactions(file_stream):
+    """Parse uploaded CSV and compute accounting summaries.
+
+    Expected columns: date, description, amount, category, gst
+    - amount and gst should be numeric
+    - category should be one of income, expense, asset, liability
+    """
+    df = pd.read_csv(file_stream)
+    df['category'] = df['category'].str.lower()
+    df['amount'] = pd.to_numeric(df['amount'], errors='coerce').fillna(0)
+    df['gst'] = pd.to_numeric(df['gst'], errors='coerce').fillna(0)
+
+    income = df[df['category'] == 'income']['amount'].sum()
+    expenses = df[df['category'] == 'expense']['amount'].sum()
+    profit_loss = income - expenses
+
+    assets = df[df['category'] == 'asset']['amount'].sum()
+    liabilities = df[df['category'] == 'liability']['amount'].sum()
+
+    gst_collected = df[df['category'] == 'income']['gst'].sum()
+    gst_paid = df[df['category'] == 'expense']['gst'].sum()
+    gst_net = gst_collected - gst_paid
+
+    return {
+        'income': income,
+        'expenses': expenses,
+        'profit_loss': profit_loss,
+        'assets': assets,
+        'liabilities': liabilities,
+        'gst_collected': gst_collected,
+        'gst_paid': gst_paid,
+        'gst_net': gst_net,
+    }
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if not file:
+            return redirect(request.url)
+        summary = parse_transactions(file)
+        return render_template('summary.html', summary=summary)
+    return render_template('index.html')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+pandas
+pytest

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<title>Accounting Dashboard</title>
+<h1>Upload Transactions CSV</h1>
+<form method="post" enctype="multipart/form-data">
+  <input type="file" name="file" accept="text/csv">
+  <input type="submit" value="Upload">
+</form>
+<p>The CSV must contain columns: <code>date, description, amount, category, gst</code>.</p>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>Accounting Summary</title>
+<h1>Accounting Summary</h1>
+<h2>Profit and Loss</h2>
+<p>Income: {{ summary.income }}</p>
+<p>Expenses: {{ summary.expenses }}</p>
+<p>Profit/Loss: {{ summary.profit_loss }}</p>
+<h2>Balance Sheet</h2>
+<p>Assets: {{ summary.assets }}</p>
+<p>Liabilities: {{ summary.liabilities }}</p>
+<h2>GST Summary</h2>
+<p>GST Collected: {{ summary.gst_collected }}</p>
+<p>GST Paid: {{ summary.gst_paid }}</p>
+<p>Net GST: {{ summary.gst_net }}</p>
+<a href="/">Upload another file</a>

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,0 +1,24 @@
+import io
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import parse_transactions
+
+
+def test_parse_transactions():
+    data = """date,description,amount,category,gst
+2024-01-01,Fee,100,income,10
+2024-01-02,Rent,50,expense,5
+2024-01-03,Furniture,200,asset,20
+2024-01-04,Loan,100,liability,0
+"""
+    summary = parse_transactions(io.StringIO(data))
+    assert summary['income'] == 100
+    assert summary['expenses'] == 50
+    assert summary['profit_loss'] == 50
+    assert summary['assets'] == 200
+    assert summary['liabilities'] == 100
+    assert summary['gst_collected'] == 10
+    assert summary['gst_paid'] == 5
+    assert summary['gst_net'] == 5


### PR DESCRIPTION
## Summary
- add Flask app for uploading transaction CSVs and generating profit & loss, balance sheet, and GST summaries
- include basic HTML templates for upload and summary pages
- add unit test for transaction parsing and requirements file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9fbcda4608322aa1ac6095734566e