### PR TITLE
Handle case-insensitive and missing columns

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,20 @@ def parse_transactions(file_stream):
     - category should be one of income, expense, asset, liability
     """
     df = pd.read_csv(file_stream)
-    df['category'] = df['category'].str.lower()
+    # Normalise column names to handle different capitalisation and spacing
+    df.columns = df.columns.str.strip().str.lower()
+
+    # Ensure required columns are present
+    required = {"date", "description", "amount", "category"}
+    missing = required - set(df.columns)
+    if missing:
+        raise KeyError(f"Missing required column(s): {', '.join(sorted(missing))}")
+
+    # GST column is optional; default to zero if not provided
+    if 'gst' not in df.columns:
+        df['gst'] = 0
+
+    df['category'] = df['category'].astype(str).str.lower()
     df['amount'] = pd.to_numeric(df['amount'], errors='coerce').fillna(0)
     df['gst'] = pd.to_numeric(df['gst'], errors='coerce').fillna(0)
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -22,3 +22,16 @@ def test_parse_transactions():
     assert summary['gst_collected'] == 10
     assert summary['gst_paid'] == 5
     assert summary['gst_net'] == 5
+
+
+def test_parse_transactions_case_insensitive_and_no_gst():
+    data = """Date,Description,Amount,Category
+2024-01-01,Fee,100,INCOME
+2024-01-02,Rent,50,Expense
+"""
+    summary = parse_transactions(io.StringIO(data))
+    assert summary['income'] == 100
+    assert summary['expenses'] == 50
+    assert summary['gst_collected'] == 0
+    assert summary['gst_paid'] == 0
+    assert summary['gst_net'] == 0


### PR DESCRIPTION
## Summary
- Normalize CSV column names to handle varying capitalization and spacing
- Treat GST column as optional, defaulting to zero when absent
- Add regression test for case-insensitive columns and missing GST

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba2225e298832280dcfb3a6e372bd2