### PR TITLE
Add filterable accounting summaries with tile-based UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Simple web dashboard for uploading transaction CSVs and generating Profit & Loss, Balance Sheet, and GST summaries for a small mortgage broking business.
 
+The dashboard now stores uploaded transactions and lets you filter results by financial year and BAS quarter. Summaries are displayed in tiles and the filtered raw transactions can be viewed in a table.
+
 ## Setup
 
 ```bash
@@ -14,7 +16,7 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Open <http://localhost:5000> in your browser and upload a CSV with columns: `date, description, amount, category, gst`.
+Open <http://localhost:5000> in your browser and upload a CSV with columns: `date, description, amount, category, gst`. After upload you can apply a financial year and BAS quarter filter to view summaries or inspect the raw data.
 
 ## Tests
 

--- a/app.py
+++ b/app.py
@@ -1,33 +1,37 @@
-from flask import Flask, render_template, request, redirect
+from flask import Flask, render_template, request, redirect, session
 import pandas as pd
 
 app = Flask(__name__)
+app.config['SECRET_KEY'] = 'dev'
 
 
-def parse_transactions(file_stream):
-    """Parse uploaded CSV and compute accounting summaries.
-
-    Expected columns: date, description, amount, category, gst
-    - amount and gst should be numeric
-    - category should be one of income, expense, asset, liability
-    """
+def load_transactions(file_stream):
+    """Read uploaded CSV file into a normalised DataFrame."""
     df = pd.read_csv(file_stream)
-    # Normalise column names to handle different capitalisation and spacing
     df.columns = df.columns.str.strip().str.lower()
 
-    # Ensure required columns are present
     required = {"date", "description", "amount", "category"}
     missing = required - set(df.columns)
     if missing:
         raise KeyError(f"Missing required column(s): {', '.join(sorted(missing))}")
 
-    # GST column is optional; default to zero if not provided
     if 'gst' not in df.columns:
         df['gst'] = 0
 
     df['category'] = df['category'].astype(str).str.lower()
     df['amount'] = pd.to_numeric(df['amount'], errors='coerce').fillna(0)
     df['gst'] = pd.to_numeric(df['gst'], errors='coerce').fillna(0)
+    df['date'] = pd.to_datetime(df['date'], errors='coerce')
+    df = df.dropna(subset=['date'])
+    return df
+
+
+def compute_summary(df, start_date=None, end_date=None):
+    """Compute accounting summary for an optional date range."""
+    if start_date is not None:
+        df = df[df['date'] >= start_date]
+    if end_date is not None:
+        df = df[df['date'] <= end_date]
 
     income = df[df['category'] == 'income']['amount'].sum()
     expenses = df[df['category'] == 'expense']['amount'].sum()
@@ -52,15 +56,57 @@ def parse_transactions(file_stream):
     }
 
 
+def parse_transactions(file_stream, start_date=None, end_date=None):
+    """Backwards compatible helper for tests; returns summary."""
+    df = load_transactions(file_stream)
+    return compute_summary(df, start_date, end_date)
+
+
 @app.route('/', methods=['GET', 'POST'])
 def index():
     if request.method == 'POST':
         file = request.files.get('file')
         if not file:
             return redirect(request.url)
-        summary = parse_transactions(file)
-        return render_template('summary.html', summary=summary)
+        df = load_transactions(file)
+        session['transactions'] = df.to_json(orient='records', date_format='iso')
+        return redirect('/summary')
     return render_template('index.html')
+
+
+@app.route('/summary')
+def summary():
+    data_json = session.get('transactions')
+    if not data_json:
+        return redirect('/')
+    df = pd.read_json(data_json, orient='records')
+
+    year = request.args.get('year', type=int)
+    bas = request.args.get('bas', type=int)
+
+    start = end = None
+    if year:
+        start = pd.Timestamp(year, 7, 1)
+        end = pd.Timestamp(year + 1, 6, 30)
+        if bas in {1, 2, 3, 4}:
+            if bas == 1:
+                start, end = pd.Timestamp(year, 7, 1), pd.Timestamp(year, 9, 30)
+            elif bas == 2:
+                start, end = pd.Timestamp(year, 10, 1), pd.Timestamp(year, 12, 31)
+            elif bas == 3:
+                start, end = pd.Timestamp(year + 1, 1, 1), pd.Timestamp(year + 1, 3, 31)
+            else:  # bas == 4
+                start, end = pd.Timestamp(year + 1, 4, 1), pd.Timestamp(year + 1, 6, 30)
+
+    summary_data = compute_summary(df, start, end)
+    filtered_df = df
+    if start is not None:
+        filtered_df = filtered_df[filtered_df['date'] >= start]
+    if end is not None:
+        filtered_df = filtered_df[filtered_df['date'] <= end]
+
+    transactions = filtered_df.to_dict(orient='records')
+    return render_template('summary.html', summary=summary_data, transactions=transactions)
 
 
 if __name__ == '__main__':

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,8 +1,22 @@
 <!doctype html>
-<title>Accounting Dashboard</title>
-<h1>Upload Transactions CSV</h1>
-<form method="post" enctype="multipart/form-data">
-  <input type="file" name="file" accept="text/csv">
-  <input type="submit" value="Upload">
-</form>
-<p>The CSV must contain columns: <code>date, description, amount, category, gst</code>.</p>
+<html>
+<head>
+  <title>Accounting Dashboard</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin: 40px;}
+    .upload-box {max-width: 400px; margin: auto; padding: 40px; border: 1px solid #ccc; border-radius: 8px; text-align: center; box-shadow: 0 2px 6px rgba(0,0,0,0.1);}
+    input[type="file"] {margin: 20px 0;}
+    input[type="submit"] {padding: 8px 16px;}
+  </style>
+</head>
+<body>
+  <div class="upload-box">
+    <h1>Upload Transactions CSV</h1>
+    <form method="post" enctype="multipart/form-data">
+      <input type="file" name="file" accept="text/csv" required>
+      <div><input type="submit" value="Upload"></div>
+    </form>
+    <p>The CSV must contain columns: <code>date, description, amount, category, gst</code>.</p>
+  </div>
+</body>
+</html>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -1,15 +1,62 @@
 <!doctype html>
-<title>Accounting Summary</title>
-<h1>Accounting Summary</h1>
-<h2>Profit and Loss</h2>
-<p>Income: {{ summary.income }}</p>
-<p>Expenses: {{ summary.expenses }}</p>
-<p>Profit/Loss: {{ summary.profit_loss }}</p>
-<h2>Balance Sheet</h2>
-<p>Assets: {{ summary.assets }}</p>
-<p>Liabilities: {{ summary.liabilities }}</p>
-<h2>GST Summary</h2>
-<p>GST Collected: {{ summary.gst_collected }}</p>
-<p>GST Paid: {{ summary.gst_paid }}</p>
-<p>Net GST: {{ summary.gst_net }}</p>
-<a href="/">Upload another file</a>
+<html>
+<head>
+  <title>Accounting Summary</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin: 20px 40px;}
+    .tiles {display: flex; flex-wrap: wrap; gap: 20px; margin-bottom: 30px;}
+    .tile {flex: 1 1 200px; background: #f5f5f5; padding: 20px; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.1);}
+    .tile h3 {margin-top: 0;}
+    table {border-collapse: collapse; width: 100%;}
+    th, td {border: 1px solid #ddd; padding: 8px; text-align: left;}
+    th {background-color: #f2f2f2;}
+    form.filter {margin-bottom: 20px;}
+    form.filter input, form.filter select {margin-right: 10px;}
+  </style>
+</head>
+<body>
+  <h1>Accounting Summary</h1>
+
+  <form class="filter" method="get">
+    <label>Financial Year: <input type="number" name="year" value="{{ request.args.get('year', '') }}" placeholder="2024"></label>
+    <label>BAS Quarter:
+      <select name="bas">
+        <option value="">All</option>
+        <option value="1" {% if request.args.get('bas') == '1' %}selected{% endif %}>Q1 (Jul-Sep)</option>
+        <option value="2" {% if request.args.get('bas') == '2' %}selected{% endif %}>Q2 (Oct-Dec)</option>
+        <option value="3" {% if request.args.get('bas') == '3' %}selected{% endif %}>Q3 (Jan-Mar)</option>
+        <option value="4" {% if request.args.get('bas') == '4' %}selected{% endif %}>Q4 (Apr-Jun)</option>
+      </select>
+    </label>
+    <button type="submit">Filter</button>
+  </form>
+
+  <div class="tiles">
+    <div class="tile"><h3>Income</h3><p>{{ summary.income }}</p></div>
+    <div class="tile"><h3>Expenses</h3><p>{{ summary.expenses }}</p></div>
+    <div class="tile"><h3>Profit / Loss</h3><p>{{ summary.profit_loss }}</p></div>
+    <div class="tile"><h3>Assets</h3><p>{{ summary.assets }}</p></div>
+    <div class="tile"><h3>Liabilities</h3><p>{{ summary.liabilities }}</p></div>
+    <div class="tile"><h3>GST Collected</h3><p>{{ summary.gst_collected }}</p></div>
+    <div class="tile"><h3>GST Paid</h3><p>{{ summary.gst_paid }}</p></div>
+    <div class="tile"><h3>Net GST</h3><p>{{ summary.gst_net }}</p></div>
+  </div>
+
+  <h2>Transactions</h2>
+  <table>
+    <tr><th>Date</th><th>Description</th><th>Amount</th><th>Category</th><th>GST</th></tr>
+    {% for t in transactions %}
+    <tr>
+      <td>{{ t.date.date() }}</td>
+      <td>{{ t.description }}</td>
+      <td>{{ t.amount }}</td>
+      <td>{{ t.category }}</td>
+      <td>{{ t.gst }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+
+  <p><a href="/">Upload another file</a></p>
+</body>
+</html>
+

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,9 +1,10 @@
 import io
 import os
 import sys
+import pandas as pd
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from app import parse_transactions
+from app import parse_transactions, load_transactions, compute_summary
 
 
 def test_parse_transactions():
@@ -35,3 +36,16 @@ def test_parse_transactions_case_insensitive_and_no_gst():
     assert summary['gst_collected'] == 0
     assert summary['gst_paid'] == 0
     assert summary['gst_net'] == 0
+
+
+def test_compute_summary_with_date_filter():
+    data = """date,description,amount,category,gst
+2024-07-01,Sale,100,income,10
+2024-08-01,Rent,50,expense,5
+2025-01-15,Sale2,200,income,20
+"""
+    df = load_transactions(io.StringIO(data))
+    summary_full = compute_summary(df)
+    summary_q1 = compute_summary(df, start_date=pd.Timestamp(2024, 7, 1), end_date=pd.Timestamp(2024, 9, 30))
+    assert summary_full['income'] == 300
+    assert summary_q1['income'] == 100


### PR DESCRIPTION
## Summary
- Parse uploaded CSVs into stored transactions and compute summaries for optional date ranges
- Add year and BAS quarter filtering with raw transaction table and tile-based summary UI
- Document filtering capabilities in README and add test for date-based filtering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba58a1e6d48322aa02062cc8780de3